### PR TITLE
Add config.formTitle for form buttons

### DIFF
--- a/js/buttons/forceDelete.js
+++ b/js/buttons/forceDelete.js
@@ -14,7 +14,7 @@ $.fn.dataTable.ext.buttons.forceDelete = {
     action: function (e, dt, node, config) {
         let editor = config.editor || dt.editor();
         editor.remove(dt.rows({selected: true}).indexes(), {
-            title: 'Force Delete Record(/s)',
+            title: config.formTitle || 'Force Delete Record(/s)',
             message: function (e, dt) {
                 let data = dt.rows(e.modifier()).data();
                 let rows = data[0].hasOwnProperty('DTE_Remove') ? data.pluck('DTE_Remove') : data.pluck('DT_RowId')

--- a/js/buttons/forceDeleteSingle.js
+++ b/js/buttons/forceDeleteSingle.js
@@ -14,7 +14,7 @@ $.fn.dataTable.ext.buttons.forceDeleteSingle = {
     action: function (e, dt, node, config) {
         let editor = config.editor || dt.editor();
         editor.remove(dt.rows({selected: true}).indexes(), {
-            title: 'Force Delete Record',
+            title: config.formTitle || 'Force Delete Record',
             message: function (e, dt) {
                 let row = dt.row({selected: true}).data();
                 let msg = row.DTE_Remove || 'Are you sure you want to force delete record # ' + row.DT_RowId + '?'

--- a/js/buttons/restore.js
+++ b/js/buttons/restore.js
@@ -14,7 +14,7 @@ $.fn.dataTable.ext.buttons.restore = {
     action: function (e, dt, node, config) {
         let editor = config.editor || dt.editor();
         editor.remove(dt.rows({selected: true}).indexes(), {
-            title: 'Restore Record',
+            title: config.formTitle || 'Restore Record',
             message: function (e, dt) {
                 let row = dt.row({selected: true}).data();
                 let msg = row.DTE_Restore || 'Are you sure you want to restore record # ' + row.DT_RowId + '?'


### PR DESCRIPTION
This PR adds the `config.formTitle` option to the restore, forceDelete and forceDeleteSingle buttons. 